### PR TITLE
fix snarkjs range

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "blake-hash": "^1.1.0",
     "blake2b": "^2.1.3",
     "circom": "0.0.35",
-    "snarkjs": "^0.1.20",
+    "snarkjs": ">=0.1.20 <=0.1.24",
     "typedarray-to-buffer": "^3.1.5",
     "web3": "^1.0.0-beta.55"
   },


### PR DESCRIPTION
### What's wrong

From offline discussion with @weijiekoh. We know some developers are using this branch of circomlib are getting errors of undefined Fr. This is because the `bn128` couldn't be imported after snarkjs version 0.1.24.

```
.../maci/contracts/node_modules/circomlib/src/poseidon.js:5
const F = bn128.Fr;
                ^

TypeError: Cannot read property 'Fr' of undefined
```

### How can it be fixed

Pin the version of snarkjs